### PR TITLE
Update digitalocean vendor-data

### DIFF
--- a/Fedora21-Cloud-Base/vendor-data.txt
+++ b/Fedora21-Cloud-Base/vendor-data.txt
@@ -1,6 +1,53 @@
 #cloud-config
+disable_root: False
+manage_etc_hosts: True
+ssh_pwauth: True
+growpart:
+ mode: off
 
--disable_root: False
--ssh_pwauth: True
--growpart:
--   mode: off
+mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
+
+cloud_init_modules:
+ - migrator
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - [ update_etc_hosts, once-per-instance ]
+ - rsyslog
+ - users-groups
+ - ssh
+
+cloud_config_modules:
+ - mounts
+ - locale
+ - set-passwords
+ - yum-add-repo
+ - package-update-upgrade-install
+ - timezone
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - disable-ec2-metadata
+ - runcmd
+
+cloud_final_modules:
+ - rightscale_userdata
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+
+system_info:
+  distro: fedora
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd


### PR DESCRIPTION
The vendor-data provided here was initially pulled from the default
Fedora cloud.cfg.  Important bits we've modified here:
- We explicitly disable the growpart module, since we're already
  taking care of that.
- We allow logins directly to the root account to keep aligned
  with our offering, and remove the fedora user account.
- We ensure we're properly managing the hostname and /etc/hosts
  as expected when the droplet is first instantiated.
- We've also removed some unnecessary configuration options to
  keep it as minimal as possible.
