### PR TITLE
Vendor Data: enable growpart

### DIFF
--- a/Fedora22-Cloud-Base/vendor-data.txt
+++ b/Fedora22-Cloud-Base/vendor-data.txt
@@ -10,11 +10,6 @@ system_info:
         templates_dir: /etc/cloud/templates
     ssh_svcname: sshd
 
-# do not need to rely on cloud-init to resize images because
-# the Digital Ocean infrastructure takes care of this.
-growpart:
-    mode: off
-
 # enable password auth (for now)
 ssh_pwauth: True
 


### PR DESCRIPTION
Now that the image is responsible for it's partition, we're not disabling growpart. 
